### PR TITLE
Fixes comments for SASS' compressed mode

### DIFF
--- a/styles/style.scss
+++ b/styles/style.scss
@@ -1,4 +1,4 @@
-/*
+/*!
 Theme Name: _s
 Theme URI: http://underscores.me/
 Author: Automattic


### PR DESCRIPTION
The first line in the starting comment in `styles/style.scss` should end with a ! so that the WordPress theme information will not be trimmed out of the style.css, in compressed sass mode.  As a result WordPress will not recognize the theme.
